### PR TITLE
conditional delete for computers now works

### DIFF
--- a/BangazonWorkforce/Controllers/ComputersController.cs
+++ b/BangazonWorkforce/Controllers/ComputersController.cs
@@ -233,8 +233,8 @@ namespace BangazonWorkforce.Controllers
                     {
                         cmd.CommandText = @"DELETE FROM Computer
                                             WHERE Id = @id
-                                            AND NOT EXISTS (SELECT EmployeeId FROM [ComputerEmployee]
-                                            WHERE EmployeeId = @id)";
+                                            AND NOT EXISTS (SELECT * FROM [ComputerEmployee]
+                                            WHERE ComputerId = @id)";
                         cmd.Parameters.Add(new SqlParameter("@id", id));
 
                         cmd.ExecuteNonQuery();


### PR DESCRIPTION
# Description

Fixed the computer delete method so that it conditionally deletes as long as a computer has never been assigned to an employee.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions

1. `git fetch --all`
1. `git checkout cb-delete-computers`
1. Run BangazonWorkforce
1. Create a new computer (without assigning to an employee) and verify that you can delete it from the database. Also, verify that you cannot delete a computer that has been assigned to an employee.


# Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added test instructions that prove my fix is effective or that my feature works
